### PR TITLE
feat: add tags to search

### DIFF
--- a/lua/telescope-orgmode/insert_link.lua
+++ b/lua/telescope-orgmode/insert_link.lua
@@ -18,6 +18,7 @@ local utils = require('telescope-orgmode.utils')
 ---@field display function
 ---@field location string,
 ---@field line string,
+---@field tags string,
 
 local function insert(prompt_bufnr)
   actions.close(prompt_bufnr)

--- a/lua/telescope-orgmode/utils.lua
+++ b/lua/telescope-orgmode/utils.lua
@@ -61,11 +61,13 @@ utils.make_entry = function(opts)
     items = {
       { width = vim.F.if_nil(opts.location_width, 20) },
       { remaining = true },
+      --{ width = vim.F.if_nil(opts.tag_width, 20) },
     },
   })
 
+  ---@param entry MatchEntry
   local function make_display(entry)
-    return displayer({ entry.location, entry.line })
+    return displayer({ entry.location, entry.tags .. ' ' .. entry.line })
   end
 
   return function(entry)
@@ -74,21 +76,24 @@ utils.make_entry = function(opts)
     local lnum = nil
     local location = vim.fn.fnamemodify(entry.filename, ':t')
     local line = ''
+    local tags = ''
 
     if headline then
       lnum = headline.position.start_line
       location = string.format('%s:%i', location, lnum)
       line = string.format('%s %s', string.rep('*', headline.level), headline.title)
+      tags = table.concat(headline.all_tags, ':')
     end
 
     return {
       value = entry,
-      ordinal = location .. ' ' .. line,
+      ordinal = location .. ' ' .. tags .. ' ' .. line,
       filename = entry.filename,
       lnum = lnum,
       display = make_display,
       location = location,
       line = line,
+      tags = tags,
     }
   end
 end


### PR DESCRIPTION
To make the filtering more useful, enritch the search entries withorgmode tags. For usability reasons the tags appear before the headline, because the user might remember the tag before the actual headline. It also helps to remove ambiguities.
