### PR TITLE
Support id links

### DIFF
--- a/lua/telescope-orgmode/actions.lua
+++ b/lua/telescope-orgmode/actions.lua
@@ -65,7 +65,7 @@ function M.insert(_)
 
     -- Link to a specific heading if is set
     if entry.value.headline then
-      destination = 'file:' .. entry.value.file.filename .. '::*' .. entry.value.headline.title
+      destination = org.get_link_to_headline(entry.value.headline)
     end
 
     org.insert_link(destination)
@@ -83,11 +83,11 @@ function M._find_orgfiles(opts, prompt_bufnr)
   M._update_picker(orgfiles, opts.prompt_titles.orgfiles, prompt_bufnr)
 end
 
-function M._update_picker(results, title, prompt_bufnr)
+function M._update_picker(finder, title, prompt_bufnr)
   local current_picker = action_state.get_current_picker(prompt_bufnr)
 
   current_picker.layout.prompt.border:change_title(title)
-  current_picker:refresh(results)
+  current_picker:refresh(finder)
 end
 
 return M

--- a/lua/telescope-orgmode/actions.lua
+++ b/lua/telescope-orgmode/actions.lua
@@ -60,13 +60,14 @@ function M.insert(_)
     ---@type MatchEntry
     local entry = action_state.get_selected_entry()
 
-    -- Link to the filename by default
-    local destination = entry.value.file.filename
-
-    -- Link to a specific heading if is set
-    if entry.value.headline then
-      destination = org.get_link_to_headline(entry.value.headline)
-    end
+    local destination = (function()
+      if entry.value.headline then
+        -- Link to a specific heading if is set
+        return org.get_link_to_headline(entry.value.headline)
+      else
+        return org.get_link_to_file(entry.value.file)
+      end
+    end)()
 
     org.insert_link(destination)
     return true

--- a/lua/telescope-orgmode/actions.lua
+++ b/lua/telescope-orgmode/actions.lua
@@ -1,3 +1,4 @@
+require('telescope-orgmode.typehints')
 local finders = require('telescope-orgmode.finders')
 local org = require('telescope-orgmode.org')
 
@@ -63,9 +64,9 @@ function M.insert(_)
     local destination = (function()
       if entry.value.headline then
         -- Link to a specific heading if is set
-        return org.get_link_to_headline(entry.value.headline)
+        return entry.value.headline:get_link()
       else
-        return org.get_link_to_file(entry.value.file)
+        return entry.value.file:get_link()
       end
     end)()
 

--- a/lua/telescope-orgmode/entry_maker/headlines.lua
+++ b/lua/telescope-orgmode/entry_maker/headlines.lua
@@ -1,11 +1,6 @@
-require('telescope-orgmode.typehints')
+require('telescope-orgmode.entry_maker.types')
 local org = require('telescope-orgmode.org')
 local entry_display = require('telescope.pickers.entry_display')
-
----@class OrgHeadlineEntry
----@field file OrgApiFile
----@field filename string
----@field headline OrgApiHeadline
 
 ---@param file_results { file: OrgApiFile, filename: string }[]
 ---@return OrgHeadlineEntry[]

--- a/lua/telescope-orgmode/entry_maker/headlines.lua
+++ b/lua/telescope-orgmode/entry_maker/headlines.lua
@@ -20,7 +20,6 @@ local function index_headlines(file_results, opts)
           file = file_entry.file,
           filename = file_entry.filename,
           headline = headline,
-          title = nil,
         }
         table.insert(results, entry)
       end

--- a/lua/telescope-orgmode/entry_maker/orgfiles.lua
+++ b/lua/telescope-orgmode/entry_maker/orgfiles.lua
@@ -1,13 +1,8 @@
-require('telescope-orgmode.typehints')
+require('telescope-orgmode.entry_maker.types')
 local org = require('telescope-orgmode.org')
 local entry_display = require('telescope.pickers.entry_display')
 
 local M = {}
-
----@class OrgFileEntry
----@field file OrgApiFile
----@field filename string
----@field title string?
 
 ---@param file_results { file: OrgApiFile, filename: string }[]
 ---@return OrgFileEntry[]

--- a/lua/telescope-orgmode/mappings.lua
+++ b/lua/telescope-orgmode/mappings.lua
@@ -1,4 +1,3 @@
-local config = require('telescope-orgmode.config')
 local to_actions = require('telescope-orgmode.actions')
 
 local M = {}

--- a/lua/telescope-orgmode/org.lua
+++ b/lua/telescope-orgmode/org.lua
@@ -31,7 +31,13 @@ end
 ---@param headline OrgApiHeadline
 ---@return string
 function M.get_link_to_headline(headline)
-  return OrgApi.get_link_to_headline(headline._section) ---@diagnostic disable-line: invisible
+  return OrgApi.get_link_to_headline(headline)
+end
+
+---@param file OrgApiFile
+---@return string
+function M.get_link_to_file(file)
+  return OrgApi.get_link_to_file(file)
 end
 
 function M.insert_link(destination)

--- a/lua/telescope-orgmode/org.lua
+++ b/lua/telescope-orgmode/org.lua
@@ -1,5 +1,7 @@
 require('telescope-orgmode.typehints')
 
+local OrgApiHeadline = require('orgmode.api.headline')
+local OrgApiFile = require('orgmode.api.file')
 local OrgApi = require('orgmode.api')
 
 local M = {}
@@ -26,18 +28,6 @@ end
 
 function M.refile(opts)
   return OrgApi.refile(opts)
-end
-
----@param headline OrgApiHeadline
----@return string
-function M.get_link_to_headline(headline)
-  return OrgApi.get_link_to_headline(headline)
-end
-
----@param file OrgApiFile
----@return string
-function M.get_link_to_file(file)
-  return OrgApi.get_link_to_file(file)
 end
 
 function M.insert_link(destination)

--- a/lua/telescope-orgmode/org.lua
+++ b/lua/telescope-orgmode/org.lua
@@ -28,6 +28,12 @@ function M.refile(opts)
   return OrgApi.refile(opts)
 end
 
+---@param headline OrgApiHeadline
+---@return string
+function M.get_link_to_headline(headline)
+  return OrgApi.get_link_to_headline(headline._section) ---@diagnostic disable-line: invisible
+end
+
 function M.insert_link(destination)
   return OrgApi.insert_link(destination)
 end

--- a/lua/telescope-orgmode/typehints.lua
+++ b/lua/telescope-orgmode/typehints.lua
@@ -1,13 +1,3 @@
----@class MatchEntry
----@field value OrgHeadlineEntry | OrgFileEntry
----@field ordinal string
----@field filename string
----@field lnum number
----@field display function
----@field location string,
----@field line string,
----@field tags string,
-
 -- Type-hints copied from nvim-orgmode to simplify development
 
 ---@class OrgFileMetadata
@@ -32,6 +22,7 @@
 ---@field filename string absolute path of the current file
 ---@field headlines OrgApiHeadline[]
 ---@field is_archive_file boolean
+---@field get_link string
 ---@field private _file OrgFile
 --
 ---@class OrgRange
@@ -64,6 +55,7 @@
 ---@field is_archived boolean headline marked with the `:ARCHIVE:` tag
 ---@field headlines OrgApiHeadline[]
 ---@field id_get_or_create number
+---@field get_link string
 ---@field private _section OrgHeadline
 ---@field private _index number
 

--- a/lua/telescope-orgmode/typehints.lua
+++ b/lua/telescope-orgmode/typehints.lua
@@ -39,6 +39,10 @@
 ---@field start_col number
 ---@field end_line number
 ---@field end_col number
+---
+---@class OrgHeadline
+---@field headline TSNode
+---@field file OrgFile
 
 ---@class OrgApiHeadline
 ---@field title string headline title without todo keyword, tags and priority. Ex. `* TODO I am a headline  :SOMETAG:` returns `I am a headline`
@@ -59,7 +63,10 @@
 ---@field priority string|nil
 ---@field is_archived boolean headline marked with the `:ARCHIVE:` tag
 ---@field headlines OrgApiHeadline[]
---
+---@field id_get_or_create number
+---@field private _section OrgHeadline
+---@field private _index number
+
 ---@class OrgApiRefileOpts
 ---@field source OrgApiHeadline
 ---@field destination OrgApiFile | OrgApiHeadline


### PR DESCRIPTION
Extends the insert-link feature to support ids, when `org_id_link_to_org_use_id` is set in orgmode. It also creates the IDs at the link target if not already present.