### PR TITLE
Make initial picker mode consistent and configuragle

### DIFF
--- a/lua/telescope-orgmode/actions.lua
+++ b/lua/telescope-orgmode/actions.lua
@@ -1,4 +1,3 @@
-require('telescope-orgmode.typehints')
 local finders = require('telescope-orgmode.finders')
 local org = require('telescope-orgmode.org')
 

--- a/lua/telescope-orgmode/config.lua
+++ b/lua/telescope-orgmode/config.lua
@@ -8,14 +8,21 @@ function M.setup(ext_opts)
   M.opts = vim.tbl_extend('force', M.opts, ext_opts or {})
 end
 
-function M.init_opts(opts, prompt_titles)
+function M.init_opts(opts, prompt_titles, default_state)
   opts = vim.tbl_extend('force', M.opts, opts or {})
+  opts.mode = opts.mode or default_state
+  if not prompt_titles[opts.mode] then
+    error("Invalid mode '" .. opts.mode .. "'. Valid modes are: " .. table.concat(vim.tbl_keys(prompt_titles), ", "))
+  end
   opts.prompt_titles = prompt_titles
   opts.states = {}
+  opts.state = { current = opts.mode, next = opts.mode }
   for state, _ in pairs(prompt_titles) do
+    if state ~= opts.mode then
+      opts.state.next = state
+    end
     table.insert(opts.states, state)
   end
-  opts.state = { current = opts.states[1], next = opts.states[2] }
   return opts
 end
 

--- a/lua/telescope-orgmode/entry_maker/headlines.lua
+++ b/lua/telescope-orgmode/entry_maker/headlines.lua
@@ -25,7 +25,7 @@ local function index_headlines(file_results, opts)
 end
 
 local M = {}
----Fetches entrys from OrgApi and extracts the relevant information
+---Fetches entries from OrgApi and extracts the relevant information
 ---@param opts any
 ---@return OrgHeadlineEntry[]
 M.get_entries = function(opts)

--- a/lua/telescope-orgmode/entry_maker/orgfiles.lua
+++ b/lua/telescope-orgmode/entry_maker/orgfiles.lua
@@ -22,7 +22,7 @@ local function index_orgfiles(file_results)
   return results
 end
 
----Fetches entrys from OrgApi and extracts the relevant information
+---Fetches entries from OrgApi and extracts the relevant information
 ---@param opts any
 ---@return OrgFileEntry[]
 M.get_entries = function(opts)

--- a/lua/telescope-orgmode/finders.lua
+++ b/lua/telescope-orgmode/finders.lua
@@ -19,4 +19,16 @@ function M.orgfiles(opts)
   })
 end
 
+-- return the correct finder for the current state
+function M.from_options(opts)
+  if opts.state.current == 'headlines' then
+    return M.headlines(opts)
+  elseif opts.state.current == 'orgfiles' then
+    return M.orgfiles(opts)
+  else
+    -- this should not happen
+    error(string.format('Invalid state %s', opts.state.current))
+  end
+end
+
 return M

--- a/lua/telescope-orgmode/mappings.lua
+++ b/lua/telescope-orgmode/mappings.lua
@@ -3,7 +3,7 @@ local to_actions = require('telescope-orgmode.actions')
 local M = {}
 
 function M.attach_mappings(map, opts)
-  map('i', '<C-Space>', to_actions.toggle_headlines_orgfiles(opts), { desc = 'Toggle headline/orgfile' })
+  map('i', '<c-space>', to_actions.toggle_headlines_orgfiles(opts), { desc = 'Toggle headline/orgfile' })
   M.attach_custom(map, opts)
 end
 

--- a/lua/telescope-orgmode/picker/insert_link.lua
+++ b/lua/telescope-orgmode/picker/insert_link.lua
@@ -11,12 +11,12 @@ return function(opts)
   opts = config.init_opts(opts, {
     headlines = 'Insert link to headline',
     orgfiles = 'Insert link to org file',
-  })
+  }, "headlines")
 
   pickers
     .new(opts, {
       prompt_title = opts.prompt_titles[opts.state.current],
-      finder = finders.headlines(opts),
+      finder = finders.from_options(opts),
       sorter = conf.generic_sorter(opts),
       previewer = conf.grep_previewer(opts),
       attach_mappings = function(_, map)

--- a/lua/telescope-orgmode/picker/refile_heading.lua
+++ b/lua/telescope-orgmode/picker/refile_heading.lua
@@ -12,14 +12,14 @@ return function(opts)
   opts = config.init_opts(opts, {
     headlines = 'Refile to headline',
     orgfiles = 'Refile to orgfile',
-  })
+  }, "headlines")
 
   local closest_headline = org.get_closest_headline()
 
   pickers
     .new(opts, {
       prompt_title = opts.prompt_titles[opts.state.current],
-      finder = finders.headlines(opts),
+      finder = finders.from_options(opts),
       sorter = conf.generic_sorter(opts),
       previewer = conf.grep_previewer(opts),
       attach_mappings = function(_, map)

--- a/lua/telescope-orgmode/picker/search_headings.lua
+++ b/lua/telescope-orgmode/picker/search_headings.lua
@@ -9,12 +9,12 @@ return function(opts)
   opts = config.init_opts(opts, {
     headlines = 'Search headlines',
     orgfiles = 'Search org files',
-  })
+  }, "headlines")
 
   pickers
     .new(opts, {
       prompt_title = opts.prompt_titles[opts.state.current],
-      finder = finders.headlines(opts),
+      finder = finders.from_options(opts),
       sorter = conf.generic_sorter(opts),
       previewer = conf.grep_previewer(opts),
       attach_mappings = function(_, map)


### PR DESCRIPTION
current, next states were set based on the iteration order of the titles table, which seemed to have put "orgfiles" in current, but the picker was always set to `finders.headlines`.  the first toggle mode bind would therefore not work consistently.

This passes the default initial state  ("headlines") explicitly. Additionally it exposes it as an option for telescope:

```
:Telescope orgmode search_headings mode=orgfiles
```

will open the picker directly in the orgfiles mode.