### PR TITLE
fix: removed orphaned require

### DIFF
--- a/lua/telescope-orgmode/actions.lua
+++ b/lua/telescope-orgmode/actions.lua
@@ -1,4 +1,3 @@
-require('telescope-orgmode.typehints')
 local finders = require('telescope-orgmode.finders')
 local org = require('telescope-orgmode.org')
 


### PR DESCRIPTION
The typehints file was removed and the types file is included elsewhere. Removing the orphaned call fixes this issue.